### PR TITLE
Emergency update to 3.9

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ pytz = "==2021.1"
 redis = "==3.5.3"
 requests = "==2.32.3"
 typing = "==3.7.4.3"
-urllib3 = "*"
+urllib3 = "==2.2.3"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -13,8 +13,9 @@ pillow = ">=8.1.0"
 pygithub = "==1.54.1"
 pytz = "==2021.1"
 redis = "==3.5.3"
-requests = "==2.32.2"
+requests = "==2.32.3"
 typing = "==3.7.4.3"
+urllib3 = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -20,5 +20,5 @@ urllib3 = "==2.2.3"
 [dev-packages]
 
 [requires]
-python_version = "3.8"
-python_full_version = "3.8.0"
+python_version = "3.9"
+python_full_version = "3.9.16"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1b50293fdc4cd094045ef53e5d023041e903eb7feb448db337348928cc77c414"
+            "sha256": "8ecdfd6157694c09e406f1a18c84be743f2764662b9b1ada1f5917468b614ead"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -562,19 +562,19 @@
         },
         "requests": {
             "hashes": [
-                "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289",
-                "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.32.2"
+            "version": "==2.32.3"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "typing": {
@@ -599,6 +599,7 @@
                 "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
                 "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==2.2.3"
         },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8ecdfd6157694c09e406f1a18c84be743f2764662b9b1ada1f5917468b614ead"
+            "sha256": "5a5b300848936174105b570335959a6f628ead912d18c2dcfa5af166c34e203f"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
System 3.8 compiled with OpenSSL 1.0. Emergency move to Python 3.9 compiled with OpenSSL 1.1.1 required for urllib3 2.2.3. Move to Python 3.12 to be performed at a later time.